### PR TITLE
Create Table Contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Darwin Subramaniam <darwinsubramaniam@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.0.1", default-features = false }
-ink_metadata = { version = "3.0.1", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", default-features = false }
-ink_storage = { version = "3.0.1", default-features = false }
-ink_lang = { version = "3.0.1", default-features = false }
-ink_prelude = { version = "3.0.1", default-features = false}
+ink_primitives = { version = "=3.0.1", default-features = false }
+ink_metadata = { version = "=3.0.1", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "=3.0.1", default-features = false }
+ink_storage = { version = "=3.0.1", default-features = false }
+ink_lang = { version = "=3.0.1", default-features = false }
+ink_prelude = { version = "=3.0.1", default-features = false}
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
@@ -30,6 +30,7 @@ std = [
     "ink_env/std",
     "ink_storage/std",
     "ink_primitives/std",
+    "ink_lang/std",
     "scale/std",
     "scale-info/std",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "metasino"
+version = "0.1.0"
+authors = ["Darwin Subramaniam <darwinsubramaniam@gmail.com>"]
+edition = "2021"
+
+[dependencies]
+ink_primitives = { version = "3.0.1", default-features = false }
+ink_metadata = { version = "3.0.1", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.1", default-features = false }
+ink_storage = { version = "3.0.1", default-features = false }
+ink_lang = { version = "3.0.1", default-features = false }
+ink_prelude = { version = "3.0.1", default-features = false}
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+
+[lib]
+name = "metasino"
+path = "lib.rs"
+crate-type = [
+	# Used for normal contract Wasm blobs.
+	"cdylib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "ink_metadata/std",
+    "ink_env/std",
+    "ink_storage/std",
+    "ink_primitives/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Metasino
+
+[![Built with ink!](https://raw.githubusercontent.com/paritytech/ink/master/.images/badge.svg)](https://github.com/paritytech/ink)

--- a/lib.rs
+++ b/lib.rs
@@ -154,30 +154,18 @@ mod metasino {
             }
         }
 
-        // #[ink(message)]
-        // pub fn get_table_state(&self) -> STATE {
-        //     self.state
-        // }
+        /// Get the current state of the table.
+        #[ink(message)]
+        pub fn get_table_state(&self) -> STATE {
+            self.state
+        }
 
+        /// check if the table is fully occupied.
         #[ink(message)]
         pub fn is_table_full(&self) -> bool {
             self.get_players_count() >= MAX_PLAYERS
         }
 
-        #[ink(message)]
-        pub fn is_table_status_staging(&self) -> bool {
-            self.state == STATE::STAGING
-        }
-
-        #[ink(message)]
-        pub fn is_table_status_playing(&self) -> bool {
-            self.state == STATE::PLAYING
-        }
-
-        #[ink(message)]
-        pub fn is_table_status_ended(&self) -> bool {
-            self.state == STATE::ENDED
-        }
 
         /// Get the current number of players in the table.
         #[ink(message)]
@@ -230,9 +218,7 @@ mod metasino {
             assert_eq!(accounts.alice, metasino.initializer);
             assert_eq!(metasino.get_players_count(), 1);
             assert_eq!(metasino.get_accumulated_pot(), 100);
-            assert_eq!(metasino.is_table_status_staging(), true);
-            assert_eq!(metasino.is_table_status_playing(), false);
-            assert_eq!(metasino.is_table_status_ended(), false);
+            assert_eq!(metasino.get_table_state(), STATE::STAGING);
         }
 
         #[ink::test]
@@ -255,9 +241,7 @@ mod metasino {
             assert_eq!(metasino.get_accumulated_pot(), 200);
             assert_eq!(metasino.get_players()[0], accounts.alice);
             assert_eq!(metasino.get_players()[1], accounts.bob);
-            assert_eq!(metasino.is_table_status_staging(), true);
-            assert_eq!(metasino.is_table_status_playing(), false);
-            assert_eq!(metasino.is_table_status_ended(), false);
+            assert_eq!(metasino.get_table_state(), STATE::STAGING);
             assert_eq!(metasino.get_required_start_bet(), 100);
         }
 
@@ -288,9 +272,7 @@ mod metasino {
             ink_env::test::set_caller::<ink_env::DefaultEnvironment>(accounts.charlie);
             metasino.register_player(100);
             metasino.start_game();
-            assert_eq!(metasino.is_table_status_staging(), false);
-            assert_eq!(metasino.is_table_status_playing(), true);
-            assert_eq!(metasino.is_table_status_ended(), false);
+            assert_eq!(metasino.get_table_state(), STATE::PLAYING);
         }
 
         #[ink::test]

--- a/lib.rs
+++ b/lib.rs
@@ -154,9 +154,16 @@ mod metasino {
 
         /// We test if the default constructor does its job.
         #[ink::test]
-        fn default_works() {
+        fn initialize_with_player_count_equal_one() {
             let metasino = Metasino::new(100);
             assert_eq!(metasino.get_players_count(), 1);
+        }
+
+        #[ink::test]
+        #[should_panic = "Player already registered"]
+        fn register_same_player_will_fail() {
+            let mut metasino = Metasino::new(100);
+            metasino.register_player(100);
         }
     }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -72,14 +72,6 @@ mod metasino {
             }
         }
 
-        /// Constructor that initializes the `bool` value to `false`.
-        ///
-        /// Constructors can delegate to other constructors.
-        #[ink(constructor)]
-        pub fn default() -> Self {
-            Self::new(Default::default())
-        }
-
         #[ink(message)]
         pub fn terminate(&mut self) {
             self.players.clear();
@@ -163,7 +155,7 @@ mod metasino {
         /// We test if the default constructor does its job.
         #[ink::test]
         fn default_works() {
-            let metasino = Metasino::default();
+            let metasino = Metasino::new(100);
             assert_eq!(metasino.get_players_count(), 1);
         }
     }

--- a/lib.rs
+++ b/lib.rs
@@ -1,0 +1,170 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use ink_lang as ink;
+
+#[ink::contract]
+mod metasino {
+
+    use ink_prelude::vec::Vec;
+
+    /// The maximum players alowed in the game participaction.
+    const MAX_PLAYERS: u8 = 10;
+    /// The minimum player required to start the game.
+    const MIN_PLAYERS: u8 = 3;
+
+    #[ink(event)]
+    pub struct NewTableOpened {
+        #[ink(topic)]
+        pub initiator: AccountId,
+        #[ink(topic)]
+        pub required_start_bet: Balance,
+    }
+
+    #[ink(event)]
+    pub struct MinimumPlayerReached {
+        #[ink(topic)]
+        pub account_id: AccountId,
+    }
+
+    /// Defines the storage of your contract.
+    /// Add new fields to the below struct in order
+    /// to add new static storage fields to your contract.
+    /// StorageLayout is used to define the layout of the storage.
+    /// SpreadLayout is used to define the layout of the spread.
+    #[ink(storage)]
+    pub struct Metasino {
+        /// Account which Initialized the contract.
+        initializer: AccountId,
+        /// Store the current number of players ready for the game.
+        players: Vec<AccountId>,
+        /// Start betting value,
+        required_start_bet: Balance,
+        /// Accumulated value in the pot.
+        pot: Balance,
+        /// The current state of the game.
+        /// Haven not figure out how to use ENUM in contract.
+        /// Temporary solutoin is to use u8 
+        /// 0: Not started
+        /// 1: Started
+        /// 3: Ended
+        state: u8,
+    }
+
+    impl Metasino {
+        /// Constructor that initializes the `bool` value to the given `init_value`.
+        #[ink(constructor)]
+        pub fn new(required_start_bet: Balance) -> Self {
+            if required_start_bet <= 0 {
+                panic!("Start bet must be greater than 0");
+            }
+            let mut players: Vec<AccountId> = Vec::new();
+            players.push(Self::env().caller());
+            Self::env().emit_event(NewTableOpened {
+                initiator: Self::env().caller(),
+                required_start_bet,
+            });
+            Self {
+                initializer: Self::env().caller(),
+                required_start_bet,
+                players,
+                pot: required_start_bet,
+                state: 0,
+            }
+        }
+
+        /// Constructor that initializes the `bool` value to `false`.
+        ///
+        /// Constructors can delegate to other constructors.
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            Self::new(Default::default())
+        }
+
+        #[ink(message)]
+        pub fn terminate(&mut self) {
+            self.players.clear();
+        }
+
+        /// Register new player into the table.
+        /// error if the player is already registered.
+        /// error if the table is full.
+        /// error if new player places bet less or more than the required start bet.
+        #[ink(message)]
+        pub fn register_player(&mut self, start_bet: Balance) {
+            let caller = Self::env().caller();
+            if self.get_players_count() >= MAX_PLAYERS {
+                panic!("Max players reached");
+            }
+
+            if start_bet != self.required_start_bet {
+                panic!(
+                    "start Bet value requires at exact {}",
+                    self.required_start_bet
+                );
+            }
+
+            self.pot += start_bet;
+            if !self.players.contains(&caller) {
+                self.players.push(caller);
+            } else {
+                panic!("Player already registered");
+            }
+        }
+
+        #[ink(message)]
+        pub fn start_game(&mut self) {
+            if self.get_players_count() < MIN_PLAYERS {
+                panic!("Minimum {} players required to start the game", MIN_PLAYERS);
+            }
+            self.state = 1;
+        }
+
+        #[ink(message)]
+        pub fn get_table_state(&self) -> u8 {
+            self.state
+        }
+
+        /// Get the current number of players in the table.
+        #[ink(message)]
+        pub fn get_players_count(&self) -> u8 {
+            self.players.len() as u8
+        }
+
+        /// Get the current accumulated pot value.
+        #[ink(message)]
+        pub fn get_accumulated_pot(&self) -> Balance {
+            self.pot
+        }
+
+        /// Get address of the player in the table.
+        #[ink(message)]
+        pub fn get_players(&self) -> Vec<AccountId> {
+            self.players.clone()
+        }
+
+        /// Get the required start bet value.
+        #[ink(message)]
+        pub fn get_required_start_bet(&self) -> Balance {
+            self.required_start_bet
+        }
+    }
+
+    /// Unit tests in Rust are normally defined within such a `#[cfg(test)]`
+    /// module and test functions are marked with a `#[test]` attribute.
+    /// The below code is technically just normal Rust code.
+    #[cfg(test)]
+    mod tests {
+        /// Imports all the definitions from the outer scope so we can use them here.
+        use super::*;
+
+        /// Imports `ink_lang` so we can use `#[ink::test]`.
+        use ink_lang as ink;
+
+        /// We test if the default constructor does its job.
+        #[ink::test]
+        fn default_works() {
+            let metasino = Metasino::default();
+            assert_eq!(metasino.get_players_count(), 1);
+        }
+    }
+}

--- a/lib.rs
+++ b/lib.rs
@@ -12,6 +12,27 @@ mod metasino {
     /// The minimum player required to start the game.
     const MIN_PLAYERS: u8 = 3;
 
+    #[derive(
+        Debug,
+        Copy,
+        Clone,
+        PartialEq,
+        Eq,
+        scale::Encode,
+        scale::Decode,
+        ink_storage::traits::SpreadLayout,
+        ink_storage::traits::PackedLayout,
+    )]
+    #[cfg_attr(
+        feature = "std",
+        derive(::scale_info::TypeInfo, ::ink_storage::traits::StorageLayout)
+    )]
+    pub enum STATE {
+        STAGING,
+        PLAYING,
+        ENDED
+    }
+
     #[ink(event)]
     pub struct NewTableOpened {
         #[ink(topic)]
@@ -47,7 +68,7 @@ mod metasino {
         /// 0: Not started
         /// 1: Started
         /// 3: Ended
-        state: u8,
+        state: STATE,
     }
 
     impl Metasino {
@@ -68,15 +89,13 @@ mod metasino {
                 required_start_bet,
                 players,
                 pot: required_start_bet,
-                state: 0,
+                state: STATE::STAGING,
             }
         }
 
         #[ink(message)]
         pub fn terminate(&mut self) {
-            if self.state == 1 {
-                panic!("Game is ongoing, cannot terminate");
-            }
+            self.table_status_guard();
             if self.get_players().contains(&Self::env().caller()) {
                 panic!("Only the initializer can terminate the game");
             }
@@ -89,9 +108,7 @@ mod metasino {
         /// error if new player places bet less or more than the required start bet.
         #[ink(message)]
         pub fn register_player(&mut self, start_bet: Balance) {
-            if self.state != 0 {
-                panic!("Table is already started/ended");
-            }
+            self.table_status_guard();
             let caller = Self::env().caller();
             if self.get_players_count() >= MAX_PLAYERS {
                 panic!("Max players reached");
@@ -112,19 +129,30 @@ mod metasino {
             }
         }
 
+        /// Start the game by extending the table to the game contract.
         #[ink(message)]
         pub fn start_game(&mut self) {
-            if self.state != 0 {
-                panic!("Table is already started/ended");
-            }
+            self.table_status_guard();
+
             if self.get_players_count() < MIN_PLAYERS {
                 panic!("Minimum {} players required to start the game", MIN_PLAYERS);
             }
-            self.state = 1;
+            self.state = STATE::PLAYING;
+        }
+
+        /// Guarding the contract from being executed in a wrong state.
+        fn table_status_guard(&self){
+            if self.state == STATE::PLAYING {
+                panic!("Game is ongoing!!");
+            }
+
+            if self.state == STATE::ENDED {
+                panic!("Game has already has ended");
+            }
         }
 
         #[ink(message)]
-        pub fn get_table_state(&self) -> u8 {
+        pub fn get_table_state(&self) -> STATE {
             self.state
         }
 
@@ -179,7 +207,7 @@ mod metasino {
             assert_eq!(accounts.alice, metasino.initializer);
             assert_eq!(metasino.get_players_count(), 1);
             assert_eq!(metasino.get_accumulated_pot(), 100);
-            assert_eq!(metasino.get_table_state(), 0);
+            assert_eq!(metasino.get_table_state(), STATE::STAGING);
         }
 
         #[ink::test]
@@ -202,7 +230,7 @@ mod metasino {
             assert_eq!(metasino.get_accumulated_pot(), 200);
             assert_eq!(metasino.get_players()[0], accounts.alice);
             assert_eq!(metasino.get_players()[1], accounts.bob);
-            assert_eq!(metasino.get_table_state(), 0);
+            assert_eq!(metasino.get_table_state(), STATE::STAGING);
             assert_eq!(metasino.get_required_start_bet(), 100);
         }
 
@@ -233,11 +261,11 @@ mod metasino {
             ink_env::test::set_caller::<ink_env::DefaultEnvironment>(accounts.charlie);
             metasino.register_player(100);
             metasino.start_game();
-            assert_eq!(metasino.get_table_state(), 1);
+            assert_eq!(metasino.get_table_state(), STATE::PLAYING);
         }
 
         #[ink::test]
-        #[should_panic = "Table is already started/ended"]
+        #[should_panic = "Game is ongoing!!"]
         fn fail_to_add_player_when_game_status_started(){
             let accounts = ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
             ink_env::test::set_caller::<ink_env::DefaultEnvironment>(accounts.alice);
@@ -253,7 +281,7 @@ mod metasino {
         }
 
         #[ink::test]
-        #[should_panic = "Game is ongoing, cannot terminate"]
+        #[should_panic = "Game is ongoing!!"]
         fn should_not_allow_termination_if_table_game_in_started_state(){
             let accounts = ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
             ink_env::test::set_caller::<ink_env::DefaultEnvironment>(accounts.alice);

--- a/lib.rs
+++ b/lib.rs
@@ -63,11 +63,6 @@ mod metasino {
         /// Accumulated value in the pot.
         pot: Balance,
         /// The current state of the game.
-        /// Haven not figure out how to use ENUM in contract.
-        /// Temporary solutoin is to use u8 
-        /// 0: Not started
-        /// 1: Started
-        /// 3: Ended
         state: STATE,
     }
 


### PR DESCRIPTION
Create Table Contract which enables a wallet to create the table by setting the initial start bet value. The wallet which initializes the contract will be the first player on the table.

Another player will be able to join the table and transfer the money to the pot. 
